### PR TITLE
ported library

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
@@ -10,14 +10,14 @@ object SerializabilitySpecification extends Properties("Serializability") {
   private def serializable[M](m: M): Boolean = {
     val baos = new ByteArrayOutputStream
     val oos = new ObjectOutputStream(baos)
-    var ois: ObjectInputStream = null
+    var ois: ObjectInputStream | Null = null
     try {
       oos.writeObject(m)
       oos.close()
       val bais = new ByteArrayInputStream(baos.toByteArray)
       ois = new ObjectInputStream(bais)
-      val m2 = ois.readObject() // just ensure we can read it back
-      ois.close()
+      val m2 = ois.nn.readObject() // just ensure we can read it back
+      ois.nn.close()
       true
     } catch {
       case thr: Throwable =>
@@ -25,7 +25,7 @@ object SerializabilitySpecification extends Properties("Serializability") {
         false
     } finally {
       oos.close()
-      if (ois != null) ois.close()
+      if (ois != null) ois.nn.close()
     }
   }
 

--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -79,7 +79,8 @@ object Cogen extends CogenArities with CogenLowPriority with CogenVersionSpecifi
     // Normalize unscaled values and scaling factors by moving powers of ten from value to scaling factor.
     @tailrec
     def normalize(unscaled: BigInteger, scale: Int): (BigInteger, Int) = {
-      val divideAndRemainder = unscaled.divideAndRemainder(BigInteger.TEN)
+      // java.math.BigInteger.divideAndRemainder | IM | returned array content should not be null.
+      val divideAndRemainder = unscaled.divideAndRemainder(BigInteger.TEN).map(_.nn)
       val quotient = divideAndRemainder(0)
       val remainder = divideAndRemainder(1)
       val canNormalize = (unscaled.abs.compareTo(BigInteger.TEN) >= 0) &&

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -294,7 +294,7 @@ object Prop {
   case object Undecided extends Status
 
   /** Evaluating the property raised an exception */
-  sealed case class Exception(e: Throwable) extends Status {
+  sealed case class Exception(e: Throwable | Null) extends Status { // e should be nullable
     override def equals(o: Any) = o match {
       case Exception(_) => true
       case _ => false
@@ -361,7 +361,7 @@ object Prop {
   lazy val passed = Prop(Result(status = True))
 
   /** A property that denotes an exception */
-  def exception(e: Throwable): Prop = Prop(Result(status = Exception(e)))
+  def exception(e: Throwable | Null): Prop = Prop(Result(status = Exception(e))) // variable can be null.
 
   /** A property that denotes an exception */
   lazy val exception: Prop = exception(null)

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -188,7 +188,7 @@ object Test {
   /** An exception was raised when trying to evaluate the property with the
    *  given concrete arguments. If an exception was raised before or during
    *  argument generation, the argument list will be empty. */
-  sealed case class PropException(args: List[Arg[Any]], e: Throwable,
+  sealed case class PropException(args: List[Arg[Any]], e: Throwable | Null,
     labels: Set[String]) extends Status
 
   trait TestCallback { self =>
@@ -323,7 +323,7 @@ object Test {
     def workerFun(workerIdx: Int): Result = {
       var n = 0  // passed tests
       var d = 0  // discarded tests
-      var res: Result = null
+      var res: Result | Null = null // variable should be nullable.
       var fm = FreqMap.empty[Set[Any]]
 
       def isExhausted = d > minSuccessfulTests * maxDiscardRatio
@@ -355,7 +355,7 @@ object Test {
       if (res == null) {
         if (isExhausted) Result(Exhausted, n, d, fm)
         else Result(Passed, n, d, fm)
-      } else res
+      } else res.nn
     }
 
     val start = System.currentTimeMillis

--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -115,7 +115,7 @@ object Pretty {
   }
 
   implicit def prettyThrowable(e: Throwable): Pretty = Pretty { prms =>
-    val strs = e.getStackTrace.map { st =>
+    val strs = e.getStackTrace.map(_.nn).map { st =>
       import st._
       getClassName+"."+getMethodName + "("+getFileName+":"+getLineNumber+")"
     }

--- a/src/test/scala/org/scalacheck/util/Pretty.scala
+++ b/src/test/scala/org/scalacheck/util/Pretty.scala
@@ -38,7 +38,7 @@ object PrettySpecification extends Properties("Pretty") {
     Prop.forAll { (input: String, lead: String, x: Int) =>
       val length = lead.length + (x & 0xff) + 1
       val res = Pretty.break(input, lead, length)
-      val lines = res.split("\n")
+      val lines = res.split("\n").map(_.nn)
       lines.forall(s => s.length <= length)
     }
 


### PR DESCRIPTION
LOC changed: 34

**Nullable variable** | 5
Variables that really can be null and should therefore have a `| Null` type.

**Nullable variable is used** | 4
* Nullable variable is assigned and used thus clearly nonnull. | 2
* or nullable variable used after `!= null` check. | 2
Requires `.nn` to fix.

**Overridden java array field** | 2
A Scala field overrides some Java array field. We need to use `Array[T | Null]` instead of `Array[T]` for the overriding to work.

**Overridden java array contents are never null** | 3
Overridden array field of type `Array[T | Null]` should have type `Array[T]`. Use `.map(_.nn)` to fix.

**Overridden java method arguments are nullable** | 6
A Scala method overrides some Java method. We need to add `|Null` to the method's parameter types to make the override still work.

**Overridden java method returns array** | 1
Overridden java method returns an array. Java arrays have type `Array[T | Null]`. Returned array must thereby be converted to have type `Array[T | Null]`.

**Overridden java arguments are never null** | 6
Argument should never be null, immediately remove nullness of parameter.

**Java method returns array** | 2
Java method returns array of type `Array[Null | T]`. We need to map it to `Array[T]`.

**Pass array into java method** | 2
Pass `Array[T]` as argument to java method that requires an array. Java arrays have type `Array[T | Null]`.

**Java classification** | 1
java.math.BigInteger.divideAndRemainder | IM
Returned Array[T | Null], contents of array are non-nullable upon code inspection. Documentation is unclear.
